### PR TITLE
Fix the test package

### DIFF
--- a/src/commonTest/kotlin/com/episode6/reflectivemockk/RawApiTest.kt
+++ b/src/commonTest/kotlin/com/episode6/reflectivemockk/RawApiTest.kt
@@ -5,7 +5,7 @@ import assertk.assertions.isEqualTo
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
 import kotlin.reflect.full.memberFunctions
 
 class RawApiTest {

--- a/src/commonTest/kotlin/com/episode6/reflectivemockk/RawApiTest.kt
+++ b/src/commonTest/kotlin/com/episode6/reflectivemockk/RawApiTest.kt
@@ -1,9 +1,7 @@
-package reflectivemockk
+package com.episode6.reflectivemockk
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import com.episode6.reflectivemockk.callTo
-import com.episode6.reflectivemockk.kotlinClass
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify

--- a/src/commonTest/kotlin/com/episode6/reflectivemockk/TheHackTest.kt
+++ b/src/commonTest/kotlin/com/episode6/reflectivemockk/TheHackTest.kt
@@ -1,12 +1,8 @@
-package reflectivemockk
+package com.episode6.reflectivemockk
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
-import com.episode6.reflectivemockk.any
-import com.episode6.reflectivemockk.findCallRecorder
-import com.episode6.reflectivemockk.kotlinClass
-import com.episode6.reflectivemockk.resolveInnerType
 import io.mockk.*
 import kotlin.reflect.*
 import kotlin.reflect.full.memberFunctions


### PR DESCRIPTION
Somehow we never got the tests into the correct package (and were importing all the methods that should have been package-local). This PR moves the tests to a matching `com.episode6.reflectivemockk` package.