### PR TITLE
Add the convenience api

### DIFF
--- a/src/commonMain/kotlin/com/episode6/reflectivemockk/ConvenienceApi.kt
+++ b/src/commonMain/kotlin/com/episode6/reflectivemockk/ConvenienceApi.kt
@@ -43,36 +43,100 @@ public inline fun <reified T : Any> reflectiveMockk(
   relaxUnitFun = relaxUnitFun,
 ).apply { reflectiveStubs(stubbing) }
 
-public class ReflectiveStubbing<T : Any>(public val self: T, private val ktype: KType) {
+/**
+ * The receiver used to conveniently define reflective stubs on a mockK.
+ */
+public class ReflectiveStubbing<T : Any>(
 
+  /**
+   * The mockK that reflective stubs are applied to.
+   */
+  public val self: T,
+
+  /**
+   * The ktype of [self], generated using [typeOf]
+   */
+  private val kType: KType,
+) {
+
+  /**
+   * Convenience accessor the [KClass] of [self]. Reflective properties and functions should all come from
+   * this instance and not [kType], since kType might be an interface with inaccessible methods.
+   */
   public val kClass: KClass<*> get() = self.kotlinClass
+
+  /**
+   * Convenience accessor for [kotlin.reflect.full.memberProperties] via [kClass]
+   */
   public val memberProperties: Collection<KProperty1<*, *>> get() = kClass.memberProperties
+
+  /**
+   * Convenience accessor for [kotlin.reflect.full.memberFunctions] via [kClass]
+   */
   public val memberFunctions: Collection<KFunction<*>> get() = kClass.memberFunctions
+
+  /**
+   * Convenience accessor for non-suspendable functions via [kClass]
+   */
   public val normalMemberFunctions: Collection<KFunction<*>> get() = memberFunctions.filter { !it.isSuspend }
+
+  /**
+   * Convenience accessor for suspendable functions via [kClass]
+   */
   public val suspendMemberFunctions: Collection<KFunction<*>> get() = memberFunctions.filter { it.isSuspend }
 
+  /**
+   * Convenience function to filter a collection of [KCallable] by return-type
+   */
   public inline fun <reified R : Any?> Collection<KCallable<*>>.filterReturnType(): Collection<KCallable<*>> =
     filter { it.returnType.classifier == R::class }
 
-  public fun MockKMatcherScope.callTo(callable: KCallable<*>): Any? = callTo(callable, self, ktype)
-  public suspend fun MockKMatcherScope.suspendCallTo(callable: KCallable<*>): Any? = suspendCallTo(callable, self, ktype)
+  /**
+   * Convenience function to reflectively match a call to the given [KCallable].
+   * [callable] must be a normal member function or property of [self].
+   */
+  public fun MockKMatcherScope.callTo(callable: KCallable<*>): Any? = callTo(callable, self, kType)
 
+  /**
+   * Convenience function to reflectively match a call to the given suspendable [KCallable].
+   * [callable] must be a suspendable member function of [self].
+   */
+  public suspend fun MockKMatcherScope.suspendCallTo(callable: KCallable<*>): Any? =
+    suspendCallTo(callable, self, kType)
+
+  /**
+   * Convenience function for every { callTo(callable) }
+   * [callable] must be a normal member function or property of [self].
+   */
   public fun everyCallTo(callable: KCallable<*>): MockKStubScope<Any?, Any?> = every { callTo(callable) }
+
+  /**
+   * Convenience function for coEvery { suspendCallTo(callable) }
+   * [callable] must be a suspendable member function of [self].
+   */
   public fun coEveryCallTo(callable: KCallable<*>): MockKStubScope<Any?, Any?> = coEvery { suspendCallTo(callable) }
 
-  public fun answerEveryCallIn(calls: Collection<KCallable<*>>, answer: AnyAnswer) {
-    calls.forEach { everyCallTo(it) answers (answer) }
-  }
+  /**
+   * Convenience function to apply the same answer to every [KCallable] in [calls]
+   */
+  public fun answerEveryCallIn(
+    calls: Collection<KCallable<*>>,
+    answer: MockKAnswerScope<Any?, Any?>.(Call) -> Any?
+  ) { calls.forEach { everyCallTo(it) answers (answer) } }
 
-  public fun coAnswerEveryCallIn(calls: Collection<KCallable<*>>, answer: CoAnyAnswer) {
-    calls.forEach { coEveryCallTo(it) coAnswers (answer) }
-  }
+  /**
+   * Convenience function to apply the same suspendable answer to [KCallable] in [calls]
+   */
+  public fun coAnswerEveryCallIn(
+    calls: Collection<KCallable<*>>,
+    answer: suspend MockKAnswerScope<Any?, Any?>.(Call) -> Any?
+  ) { calls.forEach { coEveryCallTo(it) coAnswers (answer) } }
 
-  public fun defaultAnswer(answer: AnyAnswer) {
+  /**
+   * Convenience function to apply the same answer to every member property and function in [self]
+   */
+  public fun defaultAnswer(answer: MockKAnswerScope<Any?, Any?>.(Call) -> Any?) {
     answerEveryCallIn(calls = memberProperties + normalMemberFunctions, answer)
     coAnswerEveryCallIn(calls = suspendMemberFunctions, answer)
   }
 }
-
-public typealias AnyAnswer = MockKAnswerScope<Any?, Any?>.(Call) -> Any?
-public typealias CoAnyAnswer = suspend MockKAnswerScope<Any?, Any?>.(Call) -> Any?

--- a/src/commonMain/kotlin/com/episode6/reflectivemockk/ConvenienceApi.kt
+++ b/src/commonMain/kotlin/com/episode6/reflectivemockk/ConvenienceApi.kt
@@ -1,0 +1,31 @@
+package com.episode6.reflectivemockk
+
+import io.mockk.*
+import kotlin.reflect.*
+import kotlin.reflect.full.memberFunctions
+import kotlin.reflect.full.memberProperties
+
+public inline fun <reified T : Any> T.reflectiveStubs(stubbing: ReflectiveStubbing<T>.() -> Unit) {
+  ReflectiveStubbing<T>(this, typeOf<T>()).stubbing()
+}
+
+public inline fun <reified T : Any> reflectiveMockk(stubbing: ReflectiveStubbing<T>.() -> Unit): T =
+  mockk<T>().apply { reflectiveStubs(stubbing) }
+
+public class ReflectiveStubbing<T : Any>(public val mock: T, private val ktype: KType) {
+  public val kclass: KClass<*> get() = mock.kotlinClass
+  public val functions: Collection<KFunction<*>> get() = kclass.memberFunctions.filter { !it.isSuspend }
+  public val suspendFunctions: Collection<KFunction<*>> get() = kclass.memberFunctions.filter { it.isSuspend }
+  public val properties: Collection<KProperty1<*, *>> get() = kclass.memberProperties
+
+  public fun everyCallTo(callable: KCallable<*>): MockKStubScope<Any?, Any?> = every { callTo(callable, mock, ktype) }
+  public fun coEveryCallTo(callable: KCallable<*>): MockKStubScope<Any?, Any?> = coEvery { callTo(callable, mock, ktype) }
+
+  @Suppress("UNCHECKED_CAST")
+  public fun defaultAnswer(answer: MockKAnswerScope<T, Any?>.(Call) -> T) {
+    (functions + properties).forEach { everyCallTo(it) answers(answer as AnyAnswer<T>) }
+    suspendFunctions.forEach { coEveryCallTo(it) answers(answer as AnyAnswer<T>) }
+  }
+}
+
+private typealias AnyAnswer<T> = MockKAnswerScope<Any?, Any?>.(Call) -> T

--- a/src/commonMain/kotlin/com/episode6/reflectivemockk/ConvenienceApi.kt
+++ b/src/commonMain/kotlin/com/episode6/reflectivemockk/ConvenienceApi.kt
@@ -30,6 +30,9 @@ public class ReflectiveStubbing<T : Any>(public val mock: T, private val ktype: 
   public val normalMemberFunctions: Collection<KFunction<*>> get() = memberFunctions.filter { !it.isSuspend }
   public val suspendMemberFunctions: Collection<KFunction<*>> get() = memberFunctions.filter { it.isSuspend }
 
+  public inline fun <reified R : Any?> Collection<KCallable<*>>.filterReturnType(): Collection<KCallable<*>> =
+    filter { it.returnType.classifier == R::class }
+
   public fun everyCallTo(callable: KCallable<*>): MockKStubScope<Any?, Any?> = every { callTo(callable, mock, ktype) }
   public fun coEveryCallTo(callable: KCallable<*>): MockKStubScope<Any?, Any?> =
     coEvery { suspendCallTo(callable, mock, ktype) }

--- a/src/commonMain/kotlin/com/episode6/reflectivemockk/ConvenienceApi.kt
+++ b/src/commonMain/kotlin/com/episode6/reflectivemockk/ConvenienceApi.kt
@@ -33,9 +33,11 @@ public class ReflectiveStubbing<T : Any>(public val mock: T, private val ktype: 
   public inline fun <reified R : Any?> Collection<KCallable<*>>.filterReturnType(): Collection<KCallable<*>> =
     filter { it.returnType.classifier == R::class }
 
-  public fun everyCallTo(callable: KCallable<*>): MockKStubScope<Any?, Any?> = every { callTo(callable, mock, ktype) }
-  public fun coEveryCallTo(callable: KCallable<*>): MockKStubScope<Any?, Any?> =
-    coEvery { suspendCallTo(callable, mock, ktype) }
+  public fun MockKMatcherScope.callTo(callable: KCallable<*>): Any? = callTo(callable, mock, ktype)
+  public suspend fun MockKMatcherScope.suspendCallTo(callable: KCallable<*>): Any? = suspendCallTo(callable, mock, ktype)
+
+  public fun everyCallTo(callable: KCallable<*>): MockKStubScope<Any?, Any?> = every { callTo(callable) }
+  public fun coEveryCallTo(callable: KCallable<*>): MockKStubScope<Any?, Any?> = coEvery { suspendCallTo(callable) }
 
   public fun answerEveryCallIn(calls: Collection<KCallable<*>>, answer: AnyAnswer) {
     calls.forEach { everyCallTo(it) answers (answer) }

--- a/src/commonMain/kotlin/com/episode6/reflectivemockk/ConvenienceApi.kt
+++ b/src/commonMain/kotlin/com/episode6/reflectivemockk/ConvenienceApi.kt
@@ -22,7 +22,7 @@ public inline fun <reified T : Any> T.reflectiveStubs(stubbing: ReflectiveStubbi
 }
 
 /**
- * Convenience method to create a new mockL with reflective stubs.
+ * Convenience method to create a new mockK with reflective stubs.
  *
  * Sample Usage (to support a builder):
  *

--- a/src/commonTest/kotlin/com/episode6/reflectivemockk/BuilderTest.kt
+++ b/src/commonTest/kotlin/com/episode6/reflectivemockk/BuilderTest.kt
@@ -36,4 +36,20 @@ class BuilderTest {
       builder.step3()
     }
   }
+
+  @Test fun testSimpleBuilder3() {
+    val builder = reflectiveMockk<TestBuilder> {
+      normalMemberFunctions
+        .filter { it.returnType.classifier == TestBuilder::class }
+        .forEach { everyCallTo(it) returns mock }
+    }
+
+    builder.step1().step2().step3()
+
+    verify {
+      builder.step1()
+      builder.step2()
+      builder.step3()
+    }
+  }
 }

--- a/src/commonTest/kotlin/com/episode6/reflectivemockk/BuilderTest.kt
+++ b/src/commonTest/kotlin/com/episode6/reflectivemockk/BuilderTest.kt
@@ -12,7 +12,7 @@ class BuilderTest {
   }
 
   @Test fun testSimpleBuilder() {
-    val builder = reflectiveMockk<TestBuilder> { defaultAnswer { mock } }
+    val builder = reflectiveMockk<TestBuilder> { defaultAnswer { self } }
 
     builder.step1().step2().step3()
 
@@ -25,7 +25,7 @@ class BuilderTest {
 
   @Test fun testSimpleBuilder2() {
     val builder = reflectiveMockk<TestBuilder> {
-      answerEveryCallIn(normalMemberFunctions) { mock }
+      answerEveryCallIn(normalMemberFunctions) { self }
     }
 
     builder.step1().step2().step3()
@@ -41,7 +41,7 @@ class BuilderTest {
     val builder = reflectiveMockk<TestBuilder> {
       normalMemberFunctions
         .filterReturnType<TestBuilder>()
-        .forEach { everyCallTo(it) returns mock }
+        .forEach { everyCallTo(it) returns self }
     }
 
     builder.step1().step2().step3()

--- a/src/commonTest/kotlin/com/episode6/reflectivemockk/BuilderTest.kt
+++ b/src/commonTest/kotlin/com/episode6/reflectivemockk/BuilderTest.kt
@@ -1,0 +1,39 @@
+package com.episode6.reflectivemockk
+
+import io.mockk.verify
+import kotlin.test.Test
+
+class BuilderTest {
+
+  interface TestBuilder {
+    fun step1(): TestBuilder
+    fun step2(): TestBuilder
+    fun step3(): TestBuilder
+  }
+
+  @Test fun testSimpleBuilder() {
+    val builder = reflectiveMockk<TestBuilder> { defaultAnswer { mock } }
+
+    builder.step1().step2().step3()
+
+    verify {
+      builder.step1()
+      builder.step2()
+      builder.step3()
+    }
+  }
+
+  @Test fun testSimpleBuilder2() {
+    val builder = reflectiveMockk<TestBuilder> {
+      answerEveryCallIn(normalMemberFunctions) { mock }
+    }
+
+    builder.step1().step2().step3()
+
+    verify {
+      builder.step1()
+      builder.step2()
+      builder.step3()
+    }
+  }
+}

--- a/src/commonTest/kotlin/com/episode6/reflectivemockk/BuilderTest.kt
+++ b/src/commonTest/kotlin/com/episode6/reflectivemockk/BuilderTest.kt
@@ -40,7 +40,7 @@ class BuilderTest {
   @Test fun testSimpleBuilder3() {
     val builder = reflectiveMockk<TestBuilder> {
       normalMemberFunctions
-        .filter { it.returnType.classifier == TestBuilder::class }
+        .filterReturnType<TestBuilder>()
         .forEach { everyCallTo(it) returns mock }
     }
 

--- a/src/commonTest/kotlin/com/episode6/reflectivemockk/ConvenienceApiSuspendTest.kt
+++ b/src/commonTest/kotlin/com/episode6/reflectivemockk/ConvenienceApiSuspendTest.kt
@@ -1,0 +1,58 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.episode6.reflectivemockk
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import io.mockk.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.reflect.full.memberFunctions
+
+class ConvenienceApiSuspendTest {
+  interface TestInterface {
+    suspend fun someFunction(input: String): String
+  }
+
+  interface TestGenericInterface<T> {
+    suspend fun someFunction(input: T): T
+  }
+
+  interface TestInterfaceWithGenericFunction {
+    suspend fun <T> someFunction(input: T): T
+  }
+
+  @Test fun testUsageWithSimpleInterface() = runTest {
+    val mockTestClass = mockk<TestInterface>().reflectiveStubs {
+      coAnswerEveryCallIn(suspendMemberFunctions) { "mocked" }
+    }
+
+    val result = mockTestClass.someFunction("something")
+
+    assertThat(result).isEqualTo("mocked")
+    coVerify { mockTestClass.someFunction("something") }
+  }
+
+  @Test fun testUsageWithGenericInterface() = runTest {
+    val mockTestClass = mockk<TestGenericInterface<String>>().reflectiveStubs {
+      coAnswerEveryCallIn(suspendMemberFunctions) { "mocked" }
+    }
+
+    val result = mockTestClass.someFunction("something")
+
+    assertThat(result).isEqualTo("mocked")
+    coVerify { mockTestClass.someFunction("something") }
+  }
+
+  @Test fun testUsageWithGenericFunction() = runTest {
+    val mockTestClass = mockk<TestInterfaceWithGenericFunction>().reflectiveStubs {
+      coAnswerEveryCallIn(suspendMemberFunctions) { "mocked" }
+    }
+
+    val result = mockTestClass.someFunction("something")
+
+    assertThat(result).isEqualTo("mocked")
+    coVerify { mockTestClass.someFunction("something") }
+  }
+}

--- a/src/commonTest/kotlin/com/episode6/reflectivemockk/ConvenienceApiTest.kt
+++ b/src/commonTest/kotlin/com/episode6/reflectivemockk/ConvenienceApiTest.kt
@@ -1,0 +1,54 @@
+package com.episode6.reflectivemockk
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import io.mockk.mockk
+import io.mockk.verify
+import kotlin.test.Test
+
+class ConvenienceApiTest {
+  interface TestInterface {
+    fun someFunction(input: String): String
+  }
+
+  interface TestGenericInterface<T> {
+    fun someFunction(input: T): T
+  }
+
+  interface TestInterfaceWithGenericFunction {
+    fun <T> someFunction(input: T): T
+  }
+
+  @Test fun testUsageWithSimpleInterface() {
+    val mockTestClass = mockk<TestInterface>().reflectiveStubs {
+      answerEveryCallIn(normalMemberFunctions) { "mocked" }
+    }
+
+    val result = mockTestClass.someFunction("something")
+
+    assertThat(result).isEqualTo("mocked")
+    verify { mockTestClass.someFunction("something") }
+  }
+
+  @Test fun testUsageWithGenericInterface() {
+    val mockTestClass = mockk<TestGenericInterface<String>>().reflectiveStubs {
+      answerEveryCallIn(normalMemberFunctions) { "mocked" }
+    }
+
+    val result = mockTestClass.someFunction("something")
+
+    assertThat(result).isEqualTo("mocked")
+    verify { mockTestClass.someFunction("something") }
+  }
+
+  @Test fun testUsageWithGenericFunction() {
+    val mockTestClass = mockk<TestInterfaceWithGenericFunction>().reflectiveStubs {
+      answerEveryCallIn(normalMemberFunctions) { "mocked" }
+    }
+
+    val result = mockTestClass.someFunction("something")
+
+    assertThat(result).isEqualTo("mocked")
+    verify { mockTestClass.someFunction("something") }
+  }
+}

--- a/src/commonTest/kotlin/com/episode6/reflectivemockk/SuspendBuilderTest.kt
+++ b/src/commonTest/kotlin/com/episode6/reflectivemockk/SuspendBuilderTest.kt
@@ -3,7 +3,6 @@
 package com.episode6.reflectivemockk
 
 import io.mockk.coVerify
-import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -17,7 +16,7 @@ class SuspendBuilderTest {
   }
 
   @Test fun testSimpleBuilder() = runTest {
-    val builder = reflectiveMockk<TestBuilder> { defaultAnswer { mock } }
+    val builder = reflectiveMockk<TestBuilder> { defaultAnswer { self } }
 
     builder.step1().step2().step3()
 
@@ -30,7 +29,7 @@ class SuspendBuilderTest {
 
   @Test fun testSimpleBuilder2() = runTest {
     val builder = reflectiveMockk<TestBuilder> {
-      coAnswerEveryCallIn(suspendMemberFunctions) { mock }
+      coAnswerEveryCallIn(suspendMemberFunctions) { self }
     }
 
     builder.step1().step2().step3()
@@ -46,7 +45,7 @@ class SuspendBuilderTest {
     val builder = reflectiveMockk<TestBuilder> {
       suspendMemberFunctions
         .filterReturnType<TestBuilder>()
-        .forEach { coEveryCallTo(it) returns mock }
+        .forEach { coEveryCallTo(it) returns self }
     }
 
     builder.step1().step2().step3()

--- a/src/commonTest/kotlin/com/episode6/reflectivemockk/SuspendBuilderTest.kt
+++ b/src/commonTest/kotlin/com/episode6/reflectivemockk/SuspendBuilderTest.kt
@@ -45,7 +45,7 @@ class SuspendBuilderTest {
   @Test fun testSimpleBuilder3() = runTest {
     val builder = reflectiveMockk<TestBuilder> {
       suspendMemberFunctions
-        .filter { it.returnType.classifier == TestBuilder::class }
+        .filterReturnType<TestBuilder>()
         .forEach { coEveryCallTo(it) returns mock }
     }
 

--- a/src/commonTest/kotlin/com/episode6/reflectivemockk/SuspendBuilderTest.kt
+++ b/src/commonTest/kotlin/com/episode6/reflectivemockk/SuspendBuilderTest.kt
@@ -1,0 +1,44 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.episode6.reflectivemockk
+
+import io.mockk.coVerify
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class SuspendBuilderTest {
+
+  interface TestBuilder {
+    suspend fun step1(): TestBuilder
+    suspend fun step2(): TestBuilder
+    suspend fun step3(): TestBuilder
+  }
+
+  @Test fun testSimpleBuilder() = runTest {
+    val builder = reflectiveMockk<TestBuilder> { defaultAnswer { mock } }
+
+    builder.step1().step2().step3()
+
+    coVerify {
+      builder.step1()
+      builder.step2()
+      builder.step3()
+    }
+  }
+
+  @Test fun testSimpleBuilder2() = runTest {
+    val builder = reflectiveMockk<TestBuilder> {
+      coAnswerEveryCallIn(suspendMemberFunctions) { mock }
+    }
+
+    builder.step1().step2().step3()
+
+    coVerify {
+      builder.step1()
+      builder.step2()
+      builder.step3()
+    }
+  }
+}

--- a/src/commonTest/kotlin/com/episode6/reflectivemockk/SuspendBuilderTest.kt
+++ b/src/commonTest/kotlin/com/episode6/reflectivemockk/SuspendBuilderTest.kt
@@ -41,4 +41,20 @@ class SuspendBuilderTest {
       builder.step3()
     }
   }
+
+  @Test fun testSimpleBuilder3() = runTest {
+    val builder = reflectiveMockk<TestBuilder> {
+      suspendMemberFunctions
+        .filter { it.returnType.classifier == TestBuilder::class }
+        .forEach { coEveryCallTo(it) returns mock }
+    }
+
+    builder.step1().step2().step3()
+
+    coVerify {
+      builder.step1()
+      builder.step2()
+      builder.step3()
+    }
+  }
 }


### PR DESCRIPTION
Convenience api lets us do things like this...
```kotlin
val builder = reflectiveMockk<SomeBuilder> {
  defaultAnswer { self }
}
```

or 
```kotlin
val builder = mockk<SomeBuilder>().reflectiveStubs {
  answerEveryCallIn(normalMemberFunctions.filterReturnType<SomeBuilder>()) { self }
}
```