### PR TITLE
[VERSION] Snapshot v1.1.1-SNAPSHOT

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,8 @@
 # ChangeLog
 
-### v1.1.0-SNAPSHOT - Unreleased
+### v1.1.1-SNAPSHOT - Unreleased
+
+### v1.1.0 - Released 7/3/2026
 
 - Modernize build infrastructure: Kotlin `v2.3.21`, Gradle `v9.5.1`, Dokka `v2.2.0`
 - Bump JVM target to 17

--- a/self.versions.toml
+++ b/self.versions.toml
@@ -1,2 +1,2 @@
 [versions]
-name="1.1.0-SNAPSHOT"
+name="1.1.1-SNAPSHOT"


### PR DESCRIPTION
## Summary
- Bump `self.versions.toml` to `1.1.1-SNAPSHOT` now that `release/v1.1.0` has been cut.
- Add a new "Unreleased" section in `docs/CHANGELOG.md` for v1.1.1 and mark v1.1.0 as released (7/3/2026).

Part of the standard release-branch process (see `RELEASE_CHECKLIST.md`).