### PR TITLE
[VERSION] Release v1.1.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ChangeLog
 
-### v1.1.0-SNAPSHOT - Unreleased
+### v1.1.0 - Released 7/3/2026
 
 - Modernize build infrastructure: Kotlin `v2.3.21`, Gradle `v9.5.1`, Dokka `v2.2.0`
 - Bump JVM target to 17

--- a/self.versions.toml
+++ b/self.versions.toml
@@ -1,2 +1,2 @@
 [versions]
-name="1.1.0-SNAPSHOT"
+name="1.1.0"


### PR DESCRIPTION
## Summary
- Bump `self.versions.toml` to `1.1.0` (drop `-SNAPSHOT`).
- Update `docs/CHANGELOG.md` with the release date for v1.1.0.

Part of the standard release-branch process (see `RELEASE_CHECKLIST.md`).