### PR TITLE
Only deploy root docs to website on release builds

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -110,7 +110,7 @@ jobs:
         if: github.event_name != 'pull_request'
         run: ./gradlew configSite
       - name: Deploy root docs to website
-        if: github.event_name != 'pull_request'
+        if: github.ref_type == 'tag'
         uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem
The `publish` job in `publish-artifacts.yml` runs on every push to `main` as well as on `v*` release tags, and the "Deploy root docs to website" step only excluded pull requests. Every merge to `main` therefore redeployed the site root with the current snapshot version's instructions, clobbering the latest release's docs.

## Fix
Tighten the step's condition to `if: github.ref_type == 'tag'`, so the site root is only updated by release builds (the `v*` tag pushed from a release branch when shipping). Tag pushes are never pull requests, so the previous PR exclusion is preserved. "Deploy dokka to website" is intentionally unchanged — it still runs on pushes to `main` (deploying to `/docs/main/`) as well as on release tags.

Same fix as episode6/redux-store-flow#115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ln68zwMS12XmqUefnBypep