### PR TITLE
Add Collins project icon

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### v1.1.1-SNAPSHOT - Unreleased
 
+- Add Collins sidebar icon (`project-icon.svg`) — repo tooling only, no library changes
 - CI: snapshot publishes now use Maven's timestamped unique-snapshot protocol (new
   `scripts/upload-snapshots.py`, ported from tacita — uploads timestamped filenames and
   re-PUTs each module's `maven-metadata.xml` with an incremented buildNumber). The

--- a/project-icon.svg
+++ b/project-icon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
+  <!-- reflective-mockk: a K facing its own mirror image across a reflection line
+       (kotlin-reflect + MockK). Accent is episode6 orange (#FF6600, from the org favicon). -->
+  <rect x="2" y="2" width="124" height="124" rx="26" fill="#262320" stroke="#4a443c" stroke-width="2"/>
+  <line x1="64" y1="26" x2="64" y2="102" stroke="#EDE9E1" stroke-width="5" stroke-linecap="round" stroke-dasharray="1 14"/>
+  <g stroke="#FF6600" stroke-width="13" stroke-linecap="round" fill="none">
+    <path d="M80 34 V94 M80 64 L104 38 M80 64 L104 90"/>
+  </g>
+  <g stroke="#FF6600" stroke-width="13" stroke-linecap="round" fill="none" opacity="0.45">
+    <path d="M48 34 V94 M48 64 L24 38 M48 64 L24 90"/>
+  </g>
+</svg>


### PR DESCRIPTION
Adds a `project-icon.svg` so Collins shows a custom sidebar icon for this repo instead of the generic folder.

The design is a mirrored-K motif — a bold K facing its own faded mirror image across a dotted reflection line (kotlin-reflect + MockK) — on the Collins house-style dark tile. The accent color is episode6 orange (`#FF6600`, sampled from the org favicon).

<img src="https://raw.githubusercontent.com/episode6/screenshots/main/reflective-mockk/collins-project-icon/icon-preview-20260730-205457.png" width="300" alt="Icon at 128px next to its 16px render upscaled, on a dark background" />

Left: 128px render. Right: the 16px rasterization (what the sidebar shows at default size) upscaled for inspection — verified through GdkPixbuf/librsvg, the same rendering path Collins uses.

Also adds a CHANGELOG line noting this is repo tooling only (no library changes), to satisfy docs verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F1TPNfGUinQR7PofVk8aas